### PR TITLE
Initial implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+# use the shared Yast defaults
+inherit_from:
+  /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
     on_success: never
     recipients:
       - lslezak@suse.cz
+      - mvidner@suse.cz
 
 before_install:
   - docker build -t systemd-change-guard-image .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+notifications:
+  email:
+    on_success: never
+    recipients:
+      - lslezak@suse.cz
+
+before_install:
+  - docker build -t systemd-change-guard-image .
+  # list the installed packages (just for easier debugging)
+  - docker run --rm -it systemd-change-guard-image rpm -qa | sort
+
+script:
+  - docker run --rm -it systemd-change-guard-image ./systemd_status_check.rb
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM yastdevel/ruby
+COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+
+# Systemd Service Status Check
+
+[![Build Status](https://travis-ci.org/yast/systemd-change-guard.svg?branch=master)](
+https://travis-ci.org/yast/systemd-change-guard)
+
+This repository contains a simple script which periodically checks whether
+the systemd service introduced a new state.
+
+The reason is that the YaST system services modules migh not work correctly
+when a new unhandled stated is added to systemd.
+
+## Details
+
+- The script runs the `systemctl --state=help` command to get the list of states
+  from systemd
+- The list is compared with the expected states from the `expected_states.yml` file
+- If a difference is found then it is printed and the script fails
+- The script is running inside [yastdevel/ruby](
+  https://hub.docker.com/r/yastdevel/ruby/) Docker image which is based on
+  the openSUSE Tumbleweed image and regularly updated (the systemd version in
+  the image should be always up to date)
+- The script is [configured](https://travis-ci.org/yast/systemd-change-guard/settings)
+  to start regularly as a Travis CRON job

--- a/expected_states.yml
+++ b/expected_states.yml
@@ -1,0 +1,25 @@
+---
+unit active states:
+- activating
+- active
+- deactivating
+- failed
+- inactive
+- reloading
+service unit substates:
+- auto-restart
+- dead
+- exited
+- failed
+- final-sigkill
+- final-sigterm
+- reload
+- running
+- start
+- start-post
+- start-pre
+- stop
+- stop-post
+- stop-sigabrt
+- stop-sigkill
+- stop-sigterm

--- a/systemd_status_check.rb
+++ b/systemd_status_check.rb
@@ -1,0 +1,108 @@
+#! /usr/bin/env ruby
+
+# Diff::LCS is used by rspec, it is already present in the YaST Docker image
+require "diff/lcs"
+# Rainbow is used by Rubocop, it is already present in the YaST Docker image
+require "rainbow"
+
+require "yaml"
+require "English"
+
+# run systemctl and get the help about the defined states
+# @return [String]
+def systemd_help
+  help = `systemctl --state=help`
+  raise "Cannot read systemd states help" unless $CHILD_STATUS.success?
+  help
+end
+
+# parses the systemd status help text
+# @param help [String] the input help text
+# @return [Hash<String,Array<String>>]
+def parse_status_help(help)
+  states = {}
+
+  # split the status groups
+  help.split("\n\n").each do |group|
+    lines = group.split("\n")
+    header = lines.shift
+
+    raise "Cannot parse header: #{header}" unless header =~ /Available (.*):/
+    states[Regexp.last_match[1]] = lines.sort
+  end
+
+  states
+end
+
+# read the expected states from the file
+# @param file [String] file name (YAML)
+# @return [Hash<String,Array<String>>] the loaded content
+def read_expected_states(file)
+  YAML.load_file(file)
+end
+
+# print the LCS::Diff changes
+# @param diff [Diff::LCS::ContextChange] a diff change from LCS
+def print_lsc_diff(diff)
+  case diff.action
+  when "-"
+    puts Rainbow("- #{diff.old_element}").red
+  when "+"
+    puts Rainbow("+ #{diff.new_element}").yellow
+  when "!"
+    puts Rainbow("- #{diff.old_element}").red
+    puts Rainbow("+ #{diff.new_element}").yellow
+  else
+    puts "  #{diff.old_element}"
+  end
+end
+
+# print the difference
+# @param name [String] systemd the group name (description)
+# @param expected_states [Array<String>] the expected states
+# @param current_states [Array<String>] the current states
+def print_diff(name, expected_states, current_states)
+  diffs = Diff::LCS.sdiff(expected_states, current_states)
+  puts Rainbow("Found difference in the #{name.inspect} group:").red
+  diffs.each { |d| print_lsc_diff(d) }
+  puts
+end
+
+# compare the current and the expected states
+# prints a diff if a difference is found
+# @return [Boolean] true if the states are equal
+def compare_states(expected, current)
+  compared_groups = expected.map do |name, states|
+
+    # sort the states to accept different order
+    known_states = states.sort
+    current_states = (current[name] || []).sort
+
+    if known_states == current_states
+      puts Rainbow("Found expected states in the #{name.inspect} group:").green
+      puts known_states.map { |s| "  #{s}" }.join("\n")
+      puts
+    else
+      print_diff(name, known_states, current_states)
+    end
+
+    known_states == current_states
+  end
+
+  compared_groups.all?
+end
+
+# get the current states
+current = parse_status_help(systemd_help)
+# read the expected states
+expected = read_expected_states("expected_states.yml")
+
+# compare them
+equal = compare_states(expected, current)
+
+if equal
+  puts Rainbow("Check OK, no difference found").green
+else
+  puts Rainbow("Check failed!").red
+  exit 1
+end


### PR DESCRIPTION
# Automatic Check for systemd Status Changes 

A simple script which periodically checks whether the systemd service has changes the list of known states. It runs from Travis Cron jobs and uses the already existing YaST Docker image (based on Tumbleweed). See more details in the `README.md` file.

Normally the systemd states should match the already known states:

![systemd_check_ok](https://user-images.githubusercontent.com/907998/30827593-f15fd09a-a23a-11e7-980b-1f9ddc14a7f3.png)

When a changed state is found a diff is displayed and the check fails (simulated by removing some known states from the list):

![systemd_check_failed](https://user-images.githubusercontent.com/907998/30827602-f7dd323c-a23a-11e7-8590-5db7739c92ae.png)


## Open Questions

### What to Watch?

The question is which systemd groups should be checked? We are definitely not interested in socket unit or mount unit service states. Currently the script checks only the "unit active states" and "service unit substates". Is that correct/enough?

### Notifications

Unfortunately (or fortunately, depends on the POV) Travis does not allow sending emails to any random email address. It only sends the notifications to the verified GitHub email addresses (see the [documentation](https://docs.travis-ci.com/user/notifications/#Missing-build-notifications)). That means we cannot add `yast-devel@` easily. :-(

#### Options

1. Add interested users into `.travis.yml` (do not worry, the spammers already have your email address from `*.changes` files :wink: )
1. Create a bot GitHub account and assign `yast-devel@` account to it
1. Use some 3rd party email notification system (I do not like that...)
1. Use IRC notification (in addition to emails), already tested with my fork: ![systemd_check_irc](https://user-images.githubusercontent.com/907998/30827609-fe1ca3f8-a23a-11e7-9036-fef415dea19f.png)  
(can be easily overlooked, more over IRC should be for people not for bots)

The solution 1. looks best to me.